### PR TITLE
🚑 Force version of amq-protocol to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ gitlab-shell CHANGELOG
 
 This file is used to list changes made in each version of the gitlab-shell cookbook.
 
+0.5.10
+----
+- amq-protocol 2.3.0 requires a newer version of ruby
+
 0.5.9
 ----
 - Fix versions of gems to ensure compatibility with ruby 1.9
@@ -41,7 +45,7 @@ This file is used to list changes made in each version of the gitlab-shell cookb
 
 0.3.1
 -----
-- Updated license to MIT 
+- Updated license to MIT
 
 0.1.0
 -----

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'david.martin@feedhenry.com'
 license          'MIT License'
 description      'Installs/Configures gitlab-shell'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.5.9'
+version          '0.5.10'
 
 %w(build-essential zlib readline ncurses git redisio xml ruby_build certificate).each do |cb_depend|
   depends cb_depend

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,7 +59,7 @@ if gitlab_shell['install_ruby'] !~ /package/
   end
 
   # Install required Ruby Gems for Gitlab with ~git/bin/gem
-  %w(charlock_holmes:0.7.3 bundler:1.9.9 bunny:1.7.0).each do |gempkg|
+  %w(charlock_holmes:0.7.3 bundler:1.9.9 amq-protocol:2.2.0 bunny:1.7.0).each do |gempkg|
     gem_package gempkg.split(':')[0] do
       gem_binary "#{gitlab_shell['install_ruby_path']}/bin/gem"
       action :install
@@ -69,7 +69,7 @@ if gitlab_shell['install_ruby'] !~ /package/
   end
 else
   # Install required Ruby Gems for Gitlab with system gem
-  %w(charlock_holmes:0.7.3 bundler:1.9.9 bunny:1.7.0).each do |gempkg|
+  %w(charlock_holmes:0.7.3 bundler:1.9.9 amq-protocol:2.2.0 bunny:1.7.0).each do |gempkg|
     gem_package gempkg.split(':')[0] do
       action :install
       options('--no-ri --no-rdoc')


### PR DESCRIPTION
Versions from 2.3.0 require a newer version of ruby than what we've
got installed